### PR TITLE
Upgrade SDKs for Major Version Bump

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@astrojs/check": "^0.5.10",
         "@astrojs/react": "^3.3.1",
-        "@stytch/react": "^17.0.0",
-        "@stytch/vanilla-js": "^4.9.1",
+        "@stytch/react": "^19.1.0",
+        "@stytch/vanilla-js": "^5.3.0",
         "@tanstack/react-query": "^5.32.0",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
@@ -1820,30 +1820,42 @@
       "integrity": "sha512-7fedsBfuILDTBmrYZNFI8B6ATTxhQAasUHllHmjvSZPnoq4bULWoTpHwmuQvZ8Aq03/tAa2IGo6RXqWtHdWaCA=="
     },
     "node_modules/@stytch/core": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.13.1.tgz",
-      "integrity": "sha512-U7R0YdhQmg7kQQyyB+bzOpoHcAZdeAYO3r3tvUmg7tfKvVbc0Zj83W6emQ/lq8c8xIJBkubUGtsvbK0qBgYhvA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.26.0.tgz",
+      "integrity": "sha512-qhnjIvfaMsv9QT2cFBN+4XZ1wo+EaXnSa6jxEs9AV8xhG969QNEdAv56sSgH7TQVuG/vZhHfmyoPhnhvo9lRFQ==",
       "dependencies": {
         "uuid": "8.3.2"
       }
     },
     "node_modules/@stytch/react": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@stytch/react/-/react-17.0.0.tgz",
-      "integrity": "sha512-Kz6GYKZQdeEtOT95mi+qKUG5KIE7yFMtJ2HClYIPco8rlKtFSLvDrhG1iKhOmGUfT48P01mFKH0m7OPIIpr4lA==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@stytch/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-VXxvC5OfMw4zc1P2FjyvJSLia46CFjbzyGGz8dC6+KeiRrgsRZiVuTutfe9cluLSzhFUnEHcaPfRZaFLTGx+eg==",
       "peerDependencies": {
-        "@stytch/vanilla-js": "^4.9.0",
+        "@stytch/vanilla-js": "^5.0.0",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
       }
     },
     "node_modules/@stytch/vanilla-js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.9.1.tgz",
-      "integrity": "sha512-tv23gjiMH7NrcQ06Z/WXhSAPUxNKWhd4GZDFJl6bSRedoCkSbYNYjTyVXtJuleOTppVq43HnGXVmHz0ewZjwnA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-5.3.0.tgz",
+      "integrity": "sha512-zBveMT4casOllyhCFM5KWnCXuUH4Zy6VUdBBLxWeCuJ9epVEuhyI6/F/pbBA2QCOfj1z2q5kABfggJBCy6Byqw==",
       "dependencies": {
-        "@stytch/core": "2.13.1",
-        "@types/google-one-tap": "^1.2.0"
+        "@stytch/core": "2.26.0",
+        "@types/google-one-tap": "^1.2.0",
+        "type-fest": "4.15.0"
+      }
+    },
+    "node_modules/@stytch/vanilla-js/node_modules/type-fest": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@tanstack/eslint-plugin-query": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@astrojs/check": "^0.5.10",
     "@astrojs/react": "^3.3.1",
-    "@stytch/react": "^17.0.0",
-    "@stytch/vanilla-js": "^4.9.1",
+    "@stytch/react": "^19.1.0",
+    "@stytch/vanilla-js": "^5.3.0",
     "@tanstack/react-query": "^5.32.0",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,7 @@
         "drizzle-orm": "^0.30.9",
         "express": "^4.19.2",
         "prettier": "^3.2.5",
-        "stytch": "^10.15.1"
+        "stytch": "^11.4.2"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.10",
@@ -819,14 +819,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2172,9 +2164,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.8.0.tgz",
+      "integrity": "sha512-E7CqYpL/t7MMnfGnK/eg416OsFCVUrU/Y3Vwe7QjKhu/BkS1Ms455+2xsqZQVN57/U2MHMBvEb5SrmAZWAIntA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2760,12 +2752,12 @@
       }
     },
     "node_modules/stytch": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-10.15.1.tgz",
-      "integrity": "sha512-KVOsffp2SURNEw5UwQzUx/mFKFmPpdxgwwHbgidpEDvnJXog8Uz1DuQpnwxEa6B4OMm+GW2qSTiM0zGwi8tE2Q==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-11.4.2.tgz",
+      "integrity": "sha512-3Q+1JE96XVMAJ6+zRCdze0NsOXEPLrXPS2Pff5ZKw4T/Q8V5a1kHzVDPNymRoPjTl2b8uSWm0CxShxCcVg3Ddw==",
       "dependencies": {
-        "jose": "^4.14.6",
-        "undici": "^5.25.4"
+        "jose": "^5.6.3",
+        "undici": "^6.19.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -2913,14 +2905,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
     "drizzle-orm": "^0.30.9",
     "express": "^4.19.2",
     "prettier": "^3.2.5",
-    "stytch": "^10.15.1"
+    "stytch": "^11.4.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.10",


### PR DESCRIPTION
# Description
Upgrading vanilla-js and react SDKs to account for recent version bump that introduced the following:

> Updated API routes to use api.stytch.com for live and test.stytch.com for test, replacing web.stytch.com. If you use Content Security Policy (CSP) headers, ensure the URL is updated. This was done to reduce the number of network calls and simplify internal routing, resulting in faster API response times—improving request speeds by up to 40 milliseconds roundtrip.